### PR TITLE
Add minimal watermark remover app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REPLICATE_API_TOKEN=your_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node
+node_modules/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+# Dist
+frontend/dist
+# Python
+__pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # unwatermark.ai
+
+Minimal watermark remover web app.
+
+## Setup
+
+### Backend
+```bash
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The backend reads `REPLICATE_API_TOKEN` from a `.env` file. In development CORS is open for all origins.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,77 @@
+import io
+import os
+import requests
+from fastapi import FastAPI, File, UploadFile, Form
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import Response
+from PIL import Image, ImageOps
+from dotenv import load_dotenv
+import replicate
+
+load_dotenv()
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+MAX_DIM = 2048
+
+@app.post("/api/inpaint")
+async def inpaint(
+    image: UploadFile = File(...),
+    mask: UploadFile = File(...),
+    prompt: str = Form(""),
+    negative_prompt: str = Form(""),
+    steps: int = Form(30),
+    guidance: float = Form(7.0),
+    seed: int = Form(0),
+):
+    image_bytes = await image.read()
+    img = Image.open(io.BytesIO(image_bytes))
+    img = ImageOps.exif_transpose(img)
+    if max(img.size) > MAX_DIM:
+        scale = MAX_DIM / max(img.size)
+        new_size = (int(img.width * scale), int(img.height * scale))
+        img = img.resize(new_size, Image.LANCZOS)
+
+    mask_bytes = await mask.read()
+    m = Image.open(io.BytesIO(mask_bytes)).convert("L")
+    m = ImageOps.exif_transpose(m)
+    if m.size != img.size:
+        m = m.resize(img.size, Image.NEAREST)
+
+    img_buffer = io.BytesIO()
+    img.save(img_buffer, format="PNG")
+    img_buffer.seek(0)
+
+    mask_buffer = io.BytesIO()
+    m.save(mask_buffer, format="PNG")
+    mask_buffer.seek(0)
+
+    client = replicate.Client(api_token=os.getenv("REPLICATE_API_TOKEN"))
+    output = client.run(
+        "stability-ai/stable-diffusion-xl-1.0-inpainting-0.1",
+        input={
+            "image": img_buffer,
+            "mask": mask_buffer,
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "num_inference_steps": steps,
+            "guidance_scale": guidance,
+            "seed": seed,
+        },
+    )
+
+    if isinstance(output, list):
+        image_url = output[0]
+    else:
+        image_url = output
+
+    res = requests.get(image_url)
+    res.raise_for_status()
+    return Response(content=res.content, media_type="image/png")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Watermark Remover</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"no tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.5"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,125 @@
+import { useRef, useState, useEffect } from 'react'
+
+export default function App() {
+  const [file, setFile] = useState(null)
+  const [result, setResult] = useState(null)
+  const [brush, setBrush] = useState(20)
+  const canvasRef = useRef(null)
+  const maskRef = useRef(null)
+  const drawing = useRef(false)
+  const last = useRef({ x: 0, y: 0 })
+  const imgEl = useRef(null)
+
+  useEffect(() => {
+    if (!file) return
+    const img = new Image()
+    img.onload = () => {
+      const canvas = canvasRef.current
+      const mask = maskRef.current
+      canvas.width = img.width
+      canvas.height = img.height
+      mask.width = img.width
+      mask.height = img.height
+      const ctx = canvas.getContext('2d')
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(img, 0, 0)
+      const mctx = mask.getContext('2d')
+      mctx.fillStyle = 'black'
+      mctx.fillRect(0, 0, mask.width, mask.height)
+      imgEl.current = img
+    }
+    img.src = URL.createObjectURL(file)
+  }, [file])
+
+  const getPos = (e) => {
+    const rect = canvasRef.current.getBoundingClientRect()
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top }
+  }
+
+  const start = (e) => {
+    if (!file) return
+    drawing.current = true
+    const { x, y } = getPos(e)
+    last.current = { x, y }
+  }
+
+  const draw = (e) => {
+    if (!drawing.current) return
+    const { x, y } = getPos(e)
+    const ctx = canvasRef.current.getContext('2d')
+    const mctx = maskRef.current.getContext('2d')
+    ctx.strokeStyle = 'red'
+    ctx.lineWidth = brush
+    ctx.lineCap = 'round'
+    mctx.strokeStyle = 'white'
+    mctx.lineWidth = brush
+    mctx.lineCap = 'round'
+    ctx.beginPath()
+    ctx.moveTo(last.current.x, last.current.y)
+    ctx.lineTo(x, y)
+    ctx.stroke()
+    mctx.beginPath()
+    mctx.moveTo(last.current.x, last.current.y)
+    mctx.lineTo(x, y)
+    mctx.stroke()
+    last.current = { x, y }
+  }
+
+  const end = () => {
+    drawing.current = false
+  }
+
+  const clear = () => {
+    if (!file) return
+    const canvas = canvasRef.current
+    const ctx = canvas.getContext('2d')
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.drawImage(imgEl.current, 0, 0)
+    const mctx = maskRef.current.getContext('2d')
+    mctx.fillStyle = 'black'
+    mctx.fillRect(0, 0, maskRef.current.width, maskRef.current.height)
+    setResult(null)
+  }
+
+  const remove = async () => {
+    if (!file) return
+    const maskBlob = await new Promise((resolve) => maskRef.current.toBlob(resolve, 'image/png'))
+    const form = new FormData()
+    form.append('image', file)
+    form.append('mask', maskBlob, 'mask.png')
+    const res = await fetch('/api/inpaint', { method: 'POST', body: form })
+    const blob = await res.blob()
+    setResult(URL.createObjectURL(blob))
+  }
+
+  return (
+    <div>
+      <h1>Watermark Remover</h1>
+      <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files[0])} />
+      {file && (
+        <div>
+          <canvas
+            ref={canvasRef}
+            onMouseDown={start}
+            onMouseMove={draw}
+            onMouseUp={end}
+            onMouseLeave={end}
+            style={{ border: '1px solid #ccc', cursor: 'crosshair' }}
+          />
+          <canvas ref={maskRef} style={{ display: 'none' }} />
+          <div>
+            <label>
+              Brush: <input type="range" min="1" max="100" value={brush} onChange={(e) => setBrush(+e.target.value)} />
+            </label>
+            <button onClick={clear}>Clear</button>
+            <button onClick={remove}>Remove</button>
+            {result && (
+              <a href={result} download="result.png">Download result</a>
+            )}
+          </div>
+          {result && <img src={result} alt="result" style={{ maxWidth: '100%' }} />}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+python-multipart
+pillow
+python-dotenv
+replicate
+requests


### PR DESCRIPTION
## Summary
- add FastAPI backend calling Replicate SDXL inpainting
- add Vite + React front-end with masking canvas and download
- document setup and environment variables

## Testing
- `npm test`
- `pytest`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68a61848cfb48333a4a95bc48ef1cfa0